### PR TITLE
Point the mock config to the Base Runtime Boltron compose in staging

### DIFF
--- a/resources/base-runtime-mock.cfg
+++ b/resources/base-runtime-mock.cfg
@@ -26,7 +26,7 @@ mdpolicy=group:primary
 
 # repos
 
-[demorepo]
+[buildrepo]
 name=base-runtime
 baseurl=https://kojipkgs.stg.fedoraproject.org/compose/branched/jkaluza/latest-Boltron-26/compose/base-runtime/x86_64/os/
 enabled=1

--- a/resources/base-runtime-mock.cfg
+++ b/resources/base-runtime-mock.cfg
@@ -28,7 +28,7 @@ mdpolicy=group:primary
 
 [demorepo]
 name=base-runtime
-baseurl=https://fedorapeople.org/groups/modularity/repos/base-runtime/26/
+baseurl=https://kojipkgs.stg.fedoraproject.org/compose/branched/jkaluza/latest-Boltron-26/compose/base-runtime/x86_64/os/
 enabled=1
 
 """


### PR DESCRIPTION
This compose, which contains only the Base Runtime module, is
regenerated every hour by pungi.  Maintained by Jan Kaluza.

There's another one named 'Server' which will later contain
additional Boltron modules.  We may switch to it later.

Signed-off-by: Petr Šabata <contyk@redhat.com>