### PR TITLE
added lz4-libs as expected package to be installed

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,8 +6,6 @@ service:
     port:
 packages:
     rpms:
-        - bash
-        - coreutils
 default_module: docker
 module:
     docker:

--- a/resources/installed_packages/all_installed_pkgs.txt
+++ b/resources/installed_packages/all_installed_pkgs.txt
@@ -70,6 +70,7 @@ libverto
 libxml2
 lua-libs
 lz4
+lz4-libs
 lzo
 microdnf
 mpfr


### PR DESCRIPTION
added lz4-libs as expected package to be installed.
new version of MTF will install the packages listed under packages->rpms on config.yaml file. We do not want to install any new package for our tests.