### PR TITLE
Add sssd-client packages to expected package set

### DIFF
--- a/resources/installed_packages/all_installed_pkgs_docker.txt
+++ b/resources/installed_packages/all_installed_pkgs_docker.txt
@@ -62,6 +62,8 @@ libsigsegv
 libsmartcols
 libsolv
 libssh2
+libsss_idmap
+libsss_nss_idmap
 libtasn1
 libunistring
 libutempter
@@ -103,6 +105,7 @@ sed
 setup
 shadow-utils
 sqlite-libs
+sssd-client
 systemd-libs
 tzdata
 ustr


### PR DESCRIPTION
This is needed now that sssd-client is part of the base-runtime module.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>