### PR TITLE
there is issue with avocado-init classes with multiple inheritance, missing variables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,11 @@ import cleanup
 import brtconfig
 
 
-class BaseRuntimeSetupDocker(Test, module_framework.CommonFunctions):
+class BaseRuntimeSetupDocker(Test):
 
     def setUp(self):
 
+        self.mtf = module_framework.CommonFunctions()
         self.mockcfg = brtconfig.get_mockcfg(self)
         self.br_image_name = brtconfig.get_docker_image_name(self)
 
@@ -55,7 +56,7 @@ class BaseRuntimeSetupDocker(Test, module_framework.CommonFunctions):
             self.error("mock configuration file %s does not define chroot_setup_cmd" % mockcfg)
 
         #Need to get all packages that need to be installed
-        mod_yaml = self.getModulemdYamlconfig()
+        mod_yaml = self.mtf.getModulemdYamlconfig()
         if not mod_yaml:
             self.error("Could not read modulemd Yaml file")
 

--- a/smoke.py
+++ b/smoke.py
@@ -23,6 +23,7 @@ class BaseRuntimeSmokeTest(module_framework.AvocadoTest):
         super(self.__class__, self).setUp()
         self.compiler_resource_dir = brtconfig.get_compiler_test_dir(self)
         self.compiler_test_dir = None
+        self.start()
 
     def _check_cmd_result(self, cmd, return_code, cmd_output, expect_pass=True):
         """


### PR DESCRIPTION
Fix troubles with multiple inheritance and UnitTest classes for MTF, It is better to use own instance, than using inheritance here and then use methods inside.
@bgoncalv found this.